### PR TITLE
Bug #28 - LAUCHER 엑티비티 변경 후 타이머 noti에서 딥링크 제대로 작동 안하는 버그 해결

### DIFF
--- a/app/src/main/java/com/yodi/flying/MainActivity.kt
+++ b/app/src/main/java/com/yodi/flying/MainActivity.kt
@@ -23,6 +23,8 @@ class MainActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView<ActivityMainBinding>(this, R.layout.activity_main)
 
 
+
+
         val toolbar = findViewById<Toolbar>(R.id.tool_bar)
         setSupportActionBar(toolbar)
         supportActionBar?.let {
@@ -66,6 +68,8 @@ class MainActivity : AppCompatActivity() {
         }
 
         setupTimber()
+
+        Timber.d("home 호출 ")
     }
 
     fun setToolBarTitle(title: String) {

--- a/app/src/main/java/com/yodi/flying/features/login/LogInActivity.kt
+++ b/app/src/main/java/com/yodi/flying/features/login/LogInActivity.kt
@@ -1,6 +1,5 @@
 package com.yodi.flying.features.login
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
@@ -8,14 +7,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.google.android.material.snackbar.Snackbar
 import com.kakao.sdk.auth.model.OAuthToken
-import com.kakao.sdk.user.Constants
 import com.kakao.sdk.user.UserApiClient
 import com.yodi.flying.MainActivity
 import com.yodi.flying.MainApplication
 import com.yodi.flying.R
 import com.yodi.flying.databinding.ActivityLoginBinding
 import com.yodi.flying.features.setup.SetupActivity
-import kotlinx.coroutines.*
 import timber.log.Timber
 
 
@@ -107,7 +104,7 @@ class LogInActivity : AppCompatActivity(){
     private fun navigateToSetup() {
         val intent = Intent(this, SetupActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        intent.putExtra(com.yodi.flying.utils.Constants.USER_ID_EXTRA, userId)
+        intent.putExtra(com.yodi.flying.utils.Constants.EXTRA_USER_ID, userId)
         startActivity(intent)
         finish()
     }

--- a/app/src/main/java/com/yodi/flying/features/setup/SetupActivity.kt
+++ b/app/src/main/java/com/yodi/flying/features/setup/SetupActivity.kt
@@ -3,7 +3,6 @@ package com.yodi.flying.features.setup
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
@@ -15,10 +14,8 @@ import com.yodi.flying.MainActivity
 import com.yodi.flying.MainApplication
 import com.yodi.flying.R
 import com.yodi.flying.databinding.ActivitySetupBinding
-import com.yodi.flying.features.login.LogInActivity
 import com.yodi.flying.utils.Constants
 import com.yodi.flying.utils.convertRulerValueToString
-import okhttp3.internal.Util
 import timber.log.Timber
 
 class SetupActivity : AppCompatActivity() {
@@ -38,7 +35,7 @@ class SetupActivity : AppCompatActivity() {
         binding.viewModel = setupViewmodel
         binding.lifecycleOwner = this@SetupActivity
 
-        val userId = intent.getLongExtra(Constants.USER_ID_EXTRA, -1L)
+        val userId = intent.getLongExtra(Constants.EXTRA_USER_ID, -1L)
         setupViewmodel.start(userId)
 
 

--- a/app/src/main/java/com/yodi/flying/features/splash/SplashActivity.kt
+++ b/app/src/main/java/com/yodi/flying/features/splash/SplashActivity.kt
@@ -24,7 +24,7 @@ class SplashActivity : AppCompatActivity() {
 
         val userId = (application as MainApplication).userRepository.getUserIdFromPreferences()
 
-        Timber.d("user id: $userId")
+        Timber.d("Splash 호출")
         if(userId == -1L || userId == 0L)
             navigateToLogIn()
         else
@@ -33,8 +33,9 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun navigateToHome() {
+        Timber.d("setup --> home")
         val intent = Intent(this, MainActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(intent)
         finish()
 

--- a/app/src/main/java/com/yodi/flying/features/timer/TimerFragment.kt
+++ b/app/src/main/java/com/yodi/flying/features/timer/TimerFragment.kt
@@ -63,7 +63,7 @@ class TimerFragment : Fragment(){
     override fun onStart() {
         super.onStart()
 
-        Timber.i("onStop")
+        Timber.i("onStart")
         Timber.i("timer state - time: ${timerViewmodel.timerState.value}, bound: ${bound}")
         Intent(context, TimerService::class.java).also { intent ->
             context?.bindService(intent, mConnection, Context.BIND_AUTO_CREATE)
@@ -124,7 +124,7 @@ class TimerFragment : Fragment(){
 
         // UI Setting according to pomodoroState
         timerViewmodel.pomodoroState.observe(::getLifecycle) {
-            Timber.i("pomodoro state - time: ${it}")
+            Timber.i("pomodoro state : ${it}")
 
             when(it) {
                 PomodoroState.NONE, PomodoroState.FLYING, PomodoroState.FINISHED -> {
@@ -136,12 +136,12 @@ class TimerFragment : Fragment(){
                 }
 
                 PomodoroState.SHORT_BREAK -> {
-                    binding.timerState.text = R.string.pomo_state_mealtime.toString()
+                    binding.timerState.text =  getString(R.string.pomo_state_mealtime)
 
                 }
 
                 PomodoroState.LONG_BREAK -> {
-                    binding.timerState.text = R.string.pomo_state_stopover.toString()
+                    binding.timerState.text = getString(R.string.pomo_state_stopover)
                 }
             }
         }

--- a/app/src/main/java/com/yodi/flying/service/TimerService.kt
+++ b/app/src/main/java/com/yodi/flying/service/TimerService.kt
@@ -19,7 +19,6 @@ import com.yodi.flying.model.PomodoroState
 import com.yodi.flying.model.PomodoroState.Companion.NONE
 import com.yodi.flying.model.TimerState
 
-import com.yodi.flying.utils.*
 import com.yodi.flying.utils.Constants.Companion.ACTION_CANCEL
 import com.yodi.flying.utils.Constants.Companion.ACTION_CANCEL_AND_RESET
 import com.yodi.flying.utils.Constants.Companion.ACTION_INITIALIZE_DATA
@@ -30,6 +29,7 @@ import com.yodi.flying.utils.Constants.Companion.EXTRA_POMODORO_ID
 import com.yodi.flying.utils.Constants.Companion.NOTIFICATION_ID
 import com.yodi.flying.utils.Constants.Companion.TIMER_STARTING_IN_TIME
 import com.yodi.flying.utils.Constants.Companion.TIMER_UPDATE_INTERVAL
+import com.yodi.flying.utils.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -90,8 +90,6 @@ class TimerService : LifecycleService(){
         var nowTomatoCount = 0
     }
 
-
-
     override fun onCreate() {
         super.onCreate()
 
@@ -117,7 +115,6 @@ class TimerService : LifecycleService(){
                 ACTION_START -> {
                     /*This is called when Start-Button is pressed, starting timer here and setting*/
                     Timber.i("ACTION_START")
-
                     startServiceTimer()
                 }
 
@@ -248,7 +245,6 @@ class TimerService : LifecycleService(){
         elapsedTimeInMillis.postValue(millisUntilFinished)
         if(millisUntilFinished <= lastSecondTimestamp - 1000L){
             lastSecondTimestamp -= 1000L
-            //Timber.i("onTick - lastSecondTimestamp: $lastSecondTimestamp")
             elapsedTimeInMillisEverySecond.postValue(lastSecondTimestamp)
         }
     }
@@ -349,6 +345,7 @@ class TimerService : LifecycleService(){
         if (!isInitialized) {
             intent.extras?.let {
                 val id = it.getLong(EXTRA_POMODORO_ID)
+                Timber.d("EXTRA_POMODORO_ID: $id")
                 if (id != -1L) {
                     // id is valid
                     currentNotificationBuilder
@@ -422,7 +419,7 @@ class TimerService : LifecycleService(){
         })
 
         // Observe timeInMillis and update notification
-        elapsedTimeInMillisEverySecond.observe(this, {
+        elapsedTimeInMillisEverySecond.observe(this, Observer {
             if (!isKilled && !isBound) {
                 // Only do something if timer is running and service in foreground
                 val notification = currentNotificationBuilder
@@ -431,9 +428,6 @@ class TimerService : LifecycleService(){
             }
         })
     }
-
-
-
 
 
 }

--- a/app/src/main/java/com/yodi/flying/utils/Constants.kt
+++ b/app/src/main/java/com/yodi/flying/utils/Constants.kt
@@ -14,7 +14,8 @@ class Constants {
         const val PREF_USER_ID = "PREF_USER_ID"
 
         // Intent extra
-        const val USER_ID_EXTRA = "USER_ID_EXTRA"
+        const val EXTRA_USER_ID = "EXTRA_USER_ID"
+        const val EXTRA_POMODORO_ID = "EXTRA_TIMER_ID"
 
         // Intent Actions for communication with timer service
         const val ACTION_START = "ACTION_START"
@@ -28,7 +29,7 @@ class Constants {
         const val ACTION_SOUND = "ACTION_SOUND"
         const val ACTION_SHOW_MAIN_ACTIVITY = "ACTION_SHOW_MAIN_ACTIVITY"
 
-        const val EXTRA_POMODORO_ID = "EXTRA_TIMER_ID"
+
 
         const val NOTIFICATION_CHANNEL_ID = "timer_channel"
         const val NOTIFICATION_CHANNEL_NAME = "타이머"

--- a/app/src/main/java/com/yodi/flying/utils/NotificationUtils.kt
+++ b/app/src/main/java/com/yodi/flying/utils/NotificationUtils.kt
@@ -8,11 +8,13 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.navigation.NavDeepLinkBuilder
+import com.yodi.flying.MainActivity
 import com.yodi.flying.R
 
 import com.yodi.flying.features.timer.TimerFragmentArgs
 import com.yodi.flying.utils.Constants.Companion.NOTIFICATION_CHANNEL_ID
 import com.yodi.flying.utils.Constants.Companion.NOTIFICATION_CHANNEL_NAME
+import timber.log.Timber
 
 
 fun provideBaseNotificationBuilder(
@@ -47,10 +49,13 @@ fun buildTimeFragmentPendingIntentWithId(id: Long, context: Context): PendingInt
 
     val arg = TimerFragmentArgs(id).toBundle()
 
+    Timber.d("buildTimeFragmentPendingIntentWithId 실행됨 ")
+
     return NavDeepLinkBuilder(context)
         .setGraph(R.navigation.nav_pomodoro)
         .setDestination(R.id.timerFragment)
         .setArguments(arg)
+        .setComponentName(MainActivity::class.java)
         .createPendingIntent()
 }
 


### PR DESCRIPTION
* NavHost가 기본 실행 액티비티 바깥에 있다면 setComponentName()으로 액티비티를 지정해 줘야 한다.
  + 안드로이드 문서를 차분히, 정독하는 습관을 들이자..ㅎㅎ...